### PR TITLE
Format the description of tasks and exams

### DIFF
--- a/app/src/main/java/de/david072/schoolplanner/screens/ViewTaskScreen.kt
+++ b/app/src/main/java/de/david072/schoolplanner/screens/ViewTaskScreen.kt
@@ -1,12 +1,14 @@
 package de.david072.schoolplanner.screens
 
 import android.app.Application
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
@@ -25,6 +27,7 @@ import de.david072.schoolplanner.database.repositories.ExamRepository
 import de.david072.schoolplanner.database.repositories.SubjectRepository
 import de.david072.schoolplanner.database.repositories.TaskRepository
 import de.david072.schoolplanner.ui.AppTopAppBar
+import de.david072.schoolplanner.ui.FormattedDescription
 import de.david072.schoolplanner.ui.HorizontalButton
 import de.david072.schoolplanner.ui.HorizontalSpacer
 import de.david072.schoolplanner.util.Utils
@@ -135,20 +138,35 @@ fun ViewTaskScreen(navController: NavController?, taskId: Int, isExam: Boolean =
                 icon = Icons.Outlined.School,
             )
 
-            // TODO: Prevent the text field from being selectable
-            TextField(
-                value = when {
-                    task.value != null -> task.value!!.description ?: ""
-                    exam.value != null -> exam.value!!.description ?: ""
-                    else -> ""
-                },
-                readOnly = true,
-                onValueChange = {},
+            Column(
                 modifier = Modifier
+                    .padding(top = 15.dp)
+                    .defaultMinSize(TextFieldDefaults.MinWidth, TextFieldDefaults.MinHeight)
                     .fillMaxWidth()
-                    .padding(top = 15.dp),
-                label = { Text(stringResource(R.string.add_task_description_label)) },
-            )
+                    .clip(MaterialTheme.shapes.small)
+                    .background(
+                        TextFieldDefaults
+                            .textFieldColors()
+                            .backgroundColor(true).value
+                    )
+                    .padding(top = 8.dp, start = 15.dp, end = 15.dp, bottom = 10.dp)
+            ) {
+                Text(
+                    stringResource(R.string.add_task_description_label),
+                    style = MaterialTheme.typography.caption.copy(
+                        color = MaterialTheme.colors.onSurface.copy(ContentAlpha.medium)
+                    )
+                )
+                Spacer(modifier = Modifier.height(3.dp))
+
+                FormattedDescription(
+                    source = when {
+                        task.value != null -> task.value!!.description ?: ""
+                        exam.value != null -> exam.value!!.description ?: ""
+                        else -> ""
+                    }
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/de/david072/schoolplanner/util/Utils.kt
+++ b/app/src/main/java/de/david072/schoolplanner/util/Utils.kt
@@ -8,6 +8,9 @@ import java.time.format.FormatStyle
 
 class Utils {
     companion object {
+        const val LINK_REGEX =
+            "(https?:\\/\\/(?:www\\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\\.[^\\s]{2,}|www\\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\\.[^\\s]{2,}|https?:\\/\\/(?:www\\.|(?!www))[a-zA-Z0-9]+\\.[^\\s]{2,}|www\\.[a-zA-Z0-9]+\\.[^\\s]{2,})"
+
         fun getReminderIndex(dueDate: LocalDate, reminderStartDate: LocalDate): Int {
             return when (val difference =
                 (dueDate.toEpochDay() - reminderStartDate.toEpochDay()).toInt()) {


### PR DESCRIPTION
The description of tasks and exams now supports formatting. The view
task screen now has a custom field for the description in which the
things you typed in are being formatted and displayed in a nice way.

Currently supported formats:
    - Unordered lists (aka. bullet point lists)
    - Ordered lists (1., 2., ...)
    - Links (format: [<link>](<text to be displayed>), will result in a
    underlined clickable piece of text which, on click, opens the link)

You can put as many of these formats in the description as you want.
They will be formatted at runtime and only displayed in the dedicated
field in the view task screen. In the add- and edit screens you will
still see the text form to be able to properly edit it.